### PR TITLE
Fix HTTP request issue

### DIFF
--- a/vgram.v
+++ b/vgram.v
@@ -17,7 +17,7 @@ pub fn new_bot(utoken string) Bot {
 
 fn (d Bot) http_request(method, xdata string) string {
     xreq := http.Request{
-        method: "POST"
+        method: .post
         headers: {
             'Content-Type': 'application/json'
         }


### PR DESCRIPTION
Before, it would give the error "error: cannot assign string `string` as `net.http.Method` for field `method`"