### PR TITLE
Remove unneeded comment

### DIFF
--- a/types.v
+++ b/types.v
@@ -293,7 +293,7 @@ pub:
 pub struct UserProfilePhotos {
 pub:
 	total_count int //Total number of profile pictures the target user has
-	//photos [][]PhotoSize //Requested profile pictures (in up to 4 sizes each)
+	photos [][]PhotoSize //Requested profile pictures (in up to 4 sizes each)
 }
 
 //File This object represents a file ready to be downloaded. The file can be downloaded via the link https://api.telegram.org/file/bot<token>/<file_path>. It is guaranteed that the link will be valid for at least 1 hour. When the link expires, a new one can be requested by calling getFile.


### PR DESCRIPTION
This seems to be related to an old V issue, where parsing  `[][]Something` didn't work. It does work as intended now.