### PR TITLE
Use the [params] tag for methods params

### DIFF
--- a/examples/hi_man.v
+++ b/examples/hi_man.v
@@ -8,19 +8,19 @@ fn main(){
     mut updates := []vgram.Update{}
     mut last_offset := 0
     for {
-        updates = bot.get_updates({offset: last_offset, limit: 100})
+        updates = bot.get_updates(offset: last_offset, limit: 100)
         for update in updates {
             if last_offset < update.update_id {
                 last_offset = update.update_id
                 if update.message.text == "/start" {
-                    bot.send_chat_action({
+                    bot.send_chat_action(
                         chat_id: update.message.from.id.str(),
                         action: "typing"
-                    })
-                    bot.send_message({
+                    )
+                    bot.send_message(
                         chat_id: update.message.from.id.str(),
                         text: 'Hi man'
-                    })
+                    )
                 }
             }
         }

--- a/methods.v
+++ b/methods.v
@@ -101,6 +101,7 @@ fn return_botcommands(data string) []BotCommand{
 }
 
 //GetUpdates Use this method to receive incoming updates using long polling (wiki). An Array of Update objects is returned.
+[params]
 pub struct ConfigGetUpdates {
 pub:
 	offset int //Identifier of the first update to be returned. Must be greater by one than the highest among the identifiers of previously received updates. By default, updates starting with the earliest unconfirmed update are returned. An update is considered confirmed as soon as getUpdates is called with an offset higher than its update_id. The negative offset can be specified to retrieve updates starting from -offset update from the end of the updates queue. All previous updates will forgotten.
@@ -114,6 +115,7 @@ pub fn (d Bot) get_updates(conf ConfigGetUpdates) []Update {
 }
 
 //SetWebhook Use this method to specify a url and receive incoming updates via an outgoing webhook. Whenever there is an update for the bot, we will send an HTTPS POST request to the specified url, containing a JSON-serialized Update. In case of an unsuccessful request, we will give up after a reasonable amount of attempts. Returns True on success. If you'd like to make sure that the Webhook request comes from Telegram, we recommend using a secret path in the URL, e.g. https://www.example.com/<token>. Since nobody else knows your bot‘s token, you can be pretty sure it’s us.
+[params]
 pub struct ConfigSetWebhook {
 pub:
 	url string //HTTPS url to send updates to. Use an empty string to remove webhook integration
@@ -145,6 +147,7 @@ pub fn (d Bot) get_me() User {
 }
 
 //SendMessage Use this method to send text messages. On success, the sent Message is returned.
+[params]
 pub struct ConfigSendMessage {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -161,6 +164,7 @@ pub fn (d Bot) send_message(conf ConfigSendMessage) Message {
 }
 
 //ForwardMessage Use this method to forward messages of any kind. On success, the sent Message is returned.
+[params]
 pub struct ConfigForwardMessage {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -174,6 +178,7 @@ pub fn (d Bot) forward_message(conf ConfigForwardMessage) Message {
 }
 
 //SendPhoto Use this method to send photos. On success, the sent Message is returned.
+[params]
 pub struct ConfigSendPhoto {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -190,6 +195,7 @@ pub fn (d Bot) send_photo(conf ConfigSendPhoto) Message {
 }
 
 //SendAudio Use this method to send audio files, if you want Telegram clients to display them in the music player. Your audio must be in the .MP3 or .M4A format. On success, the sent Message is returned. Bots can currently send audio files of up to 50 MB in size, this limit may be changed in the future. For sending voice messages, use the sendVoice method instead.
+[params]
 pub struct ConfigSendAudio {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -210,6 +216,7 @@ pub fn (d Bot) send_audio(conf ConfigSendAudio) Message {
 }
 
 //SendDocument Use this method to send general files. On success, the sent Message is returned. Bots can currently send files of any type of up to 50 MB in size, this limit may be changed in the future.
+[params]
 pub struct ConfigSendDocument {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -227,6 +234,7 @@ pub fn (d Bot) send_document(conf ConfigSendDocument) Message {
 }
 
 //SendVideo Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as Document). On success, the sent Message is returned. Bots can currently send video files of up to 50 MB in size, this limit may be changed in the future.
+[params]
 pub struct ConfigSendVideo {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -248,6 +256,7 @@ pub fn (d Bot) send_video(conf ConfigSendVideo) Message {
 }
 
 //SendAnimation Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound). On success, the sent Message is returned. Bots can currently send animation files of up to 50 MB in size, this limit may be changed in the future.
+[params]
 pub struct ConfigSendAnimation {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -268,6 +277,7 @@ pub fn (d Bot) send_animation(conf ConfigSendAnimation) Message {
 }
 
 //SendVoice Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .OGG file encoded with OPUS (other formats may be sent as Audio or Document). On success, the sent Message is returned. Bots can currently send voice messages of up to 50 MB in size, this limit may be changed in the future.
+[params]
 pub struct ConfigSendVoice {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -285,6 +295,7 @@ pub fn (d Bot) send_voice(conf ConfigSendVoice) Message {
 }
 
 //SendVideoNote As of v.4.0, Telegram clients support rounded square mp4 videos of up to 1 minute long. Use this method to send video messages. On success, the sent Message is returned.
+[params]
 pub struct ConfigSendVideoNote {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -302,6 +313,7 @@ pub fn (d Bot) send_video_note(conf ConfigSendVideoNote) Message {
 }
 
 //SendMediaGroup Use this method to send a group of photos or videos as an album. On success, an array of the sent Messages is returned.
+[params]
 pub struct ConfigSendMediaGroup {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -315,6 +327,7 @@ pub fn (d Bot) send_media_group(conf ConfigSendMediaGroup) []Message {
 }
 
 //SendLocation Use this method to send point on the map. On success, the sent Message is returned.
+[params]
 pub struct ConfigSendLocation {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -331,6 +344,7 @@ pub fn (d Bot) send_location(conf ConfigSendLocation) Message {
 }
 
 //EditMessageLiveLocation Use this method to edit live location messages. A location can be edited until its live_period expires or editing is explicitly disabled by a call to stopMessageLiveLocation. On success, if the edited message was sent by the bot, the edited Message is returned, otherwise True is returned.
+[params]
 pub struct ConfigEditMessageLiveLocation {
 pub:
 	chat_id string //Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -346,6 +360,7 @@ pub fn (d Bot) edit_message_live_location(conf ConfigEditMessageLiveLocation) Me
 }
 
 //StopMessageLiveLocation Use this method to stop updating a live location message before live_period expires. On success, if the message was sent by the bot, the sent Message is returned, otherwise True is returned.
+[params]
 pub struct ConfigStopMessageLiveLocation {
 pub:
 	chat_id string //Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -359,6 +374,7 @@ pub fn (d Bot) stop_message_live_location(conf ConfigStopMessageLiveLocation) Me
 }
 
 //SendVenue Use this method to send information about a venue. On success, the sent Message is returned.
+[params]
 pub struct ConfigSendVenue {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -378,6 +394,7 @@ pub fn (d Bot) send_venue(conf ConfigSendVenue) Message {
 }
 
 //SendContact Use this method to send phone contacts. On success, the sent Message is returned.
+[params]
 pub struct ConfigSendContact {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -395,6 +412,7 @@ pub fn (d Bot) send_contact(conf ConfigSendContact) Message {
 }
 
 //SendPoll Use this method to send a native poll. On success, the sent Message is returned.
+[params]
 pub struct ConfigSendPoll {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -419,6 +437,7 @@ pub fn (d Bot) send_poll(conf ConfigSendPoll) Message {
 }
 
 //SendDice Use this method to send a dice, which will have a random value from 1 to 6. On success, the sent Message is returned. (Yes, we're aware of the “proper” singular of die. But it's awkward, and we decided to help it change. One dice at a time!)
+[params]
 pub struct ConfigSendDice {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -433,6 +452,7 @@ pub fn (d Bot) send_dice(conf ConfigSendDice) Message {
 }
 
 //SendChatAction Use this method when you need to tell the user that something is happening on the bot's side. The status is set for 5 seconds or less (when a message arrives from your bot, Telegram clients clear its typing status). Returns True on success. We only recommend using this method when a response from the bot will take a noticeable amount of time to arrive.
+[params]
 pub struct ConfigSendChatAction {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -444,6 +464,7 @@ pub fn (d Bot) send_chat_action(conf ConfigSendChatAction) bool {
 }
 
 //GetUserProfilePhotos Use this method to get a list of profile pictures for a user. Returns a UserProfilePhotos object.
+[params]
 pub struct ConfigGetUserProfilePhotos {
 pub:
 	user_id int //Unique identifier of the target user
@@ -456,6 +477,7 @@ pub fn (d Bot) get_user_profile_photos(conf ConfigGetUserProfilePhotos) UserProf
 }
 
 //GetFile Use this method to get basic info about a file and prepare it for downloading. For the moment, bots can download files of up to 20MB in size. On success, a File object is returned. The file can then be downloaded via the link https://api.telegram.org/file/bot<token>/<file_path>, where <file_path> is taken from the response. It is guaranteed that the link will be valid for at least 1 hour. When the link expires, a new one can be requested by calling getFile again.
+[params]
 pub struct ConfigGetFile {
 pub:
 	file_id string //File identifier to get info about
@@ -466,6 +488,7 @@ pub fn (d Bot) get_file(conf ConfigGetFile) File {
 }
 
 //KickChatMember Use this method to kick a user from a group, a supergroup or a channel. In the case of supergroups and channels, the user will not be able to return to the group on their own using invite links, etc., unless unbanned first. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns True on success.
+[params]
 pub struct ConfigKickChatMember {
 pub:
 	chat_id string //Unique identifier for the target group or username of the target supergroup or channel (in the format @channelusername)
@@ -478,6 +501,7 @@ pub fn (d Bot) kick_chat_member(conf ConfigKickChatMember) bool {
 }
 
 //UnbanChatMember Use this method to unban a previously kicked user in a supergroup or channel. The user will not return to the group or channel automatically, but will be able to join via link, etc. The bot must be an administrator for this to work. Returns True on success.
+[params]
 pub struct ConfigUnbanChatMember {
 pub:
 	chat_id string //Unique identifier for the target group or username of the target supergroup or channel (in the format @username)
@@ -489,6 +513,7 @@ pub fn (d Bot) unban_chat_member(conf ConfigUnbanChatMember) bool {
 }
 
 //RestrictChatMember Use this method to restrict a user in a supergroup. The bot must be an administrator in the supergroup for this to work and must have the appropriate admin rights. Pass True for all permissions to lift restrictions from a user. Returns True on success.
+[params]
 pub struct ConfigRestrictChatMember {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
@@ -502,6 +527,7 @@ pub fn (d Bot) restrict_chat_member(conf ConfigRestrictChatMember) bool {
 }
 
 //PromoteChatMember Use this method to promote or demote a user in a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Pass False for all boolean parameters to demote a user. Returns True on success.
+[params]
 pub struct ConfigPromoteChatMember {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -521,6 +547,7 @@ pub fn (d Bot) promote_chat_member(conf ConfigPromoteChatMember) bool {
 }
 
 //SetChatAdministratorCustomTitle Use this method to set a custom title for an administrator in a supergroup promoted by the bot. Returns True on success.
+[params]
 pub struct ConfigSetChatAdministratorCustomTitle {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
@@ -533,6 +560,7 @@ pub fn (d Bot) set_chat_administrator_custom_title(conf ConfigSetChatAdministrat
 }
 
 //SetChatPermissions Use this method to set default chat permissions for all members. The bot must be an administrator in the group or a supergroup for this to work and must have the can_restrict_members admin rights. Returns True on success.
+[params]
 pub struct ConfigSetChatPermissions {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
@@ -544,6 +572,7 @@ pub fn (d Bot) set_chat_permissions(conf ConfigSetChatPermissions) bool {
 }
 
 //ExportChatInviteLink Use this method to generate a new invite link for a chat; any previously generated link is revoked. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns the new invite link as String on success.
+[params]
 pub struct ConfigExportChatInviteLink {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -554,6 +583,7 @@ pub fn (d Bot) export_chat_invite_link(conf ConfigExportChatInviteLink) string {
 }
 
 //SetChatPhoto Use this method to set a new profile photo for the chat. Photos can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns True on success.
+[params]
 pub struct ConfigSetChatPhoto {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -565,6 +595,7 @@ pub fn (d Bot) set_chat_photo(conf ConfigSetChatPhoto) bool {
 }
 
 //DeleteChatPhoto Use this method to delete a chat photo. Photos can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns True on success.
+[params]
 pub struct ConfigDeleteChatPhoto {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -575,6 +606,7 @@ pub fn (d Bot) delete_chat_photo(conf ConfigDeleteChatPhoto) bool {
 }
 
 //SetChatTitle Use this method to change the title of a chat. Titles can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns True on success.
+[params]
 pub struct ConfigSetChatTitle {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -586,6 +618,7 @@ pub fn (d Bot) set_chat_title(conf ConfigSetChatTitle) bool {
 }
 
 //SetChatDescription Use this method to change the description of a group, a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns True on success.
+[params]
 pub struct ConfigSetChatDescription {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -597,6 +630,7 @@ pub fn (d Bot) set_chat_description(conf ConfigSetChatDescription) bool {
 }
 
 //PinChatMessage Use this method to pin a message in a group, a supergroup, or a channel. The bot must be an administrator in the chat for this to work and must have the ‘can_pin_messages’ admin right in the supergroup or ‘can_edit_messages’ admin right in the channel. Returns True on success.
+[params]
 pub struct ConfigPinChatMessage {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -609,6 +643,7 @@ pub fn (d Bot) pin_chat_message(conf ConfigPinChatMessage) bool {
 }
 
 //UnpinChatMessage Use this method to unpin a message in a group, a supergroup, or a channel. The bot must be an administrator in the chat for this to work and must have the ‘can_pin_messages’ admin right in the supergroup or ‘can_edit_messages’ admin right in the channel. Returns True on success.
+[params]
 pub struct ConfigUnpinChatMessage {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -619,6 +654,7 @@ pub fn (d Bot) unpin_chat_message(conf ConfigUnpinChatMessage) bool {
 }
 
 //LeaveChat Use this method for your bot to leave a group, supergroup or channel. Returns True on success.
+[params]
 pub struct ConfigLeaveChat {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername)
@@ -629,6 +665,7 @@ pub fn (d Bot) leave_chat(conf ConfigLeaveChat) bool {
 }
 
 //GetChat Use this method to get up to date information about the chat (current name of the user for one-on-one conversations, current username of a user, group or channel, etc.). Returns a Chat object on success.
+[params]
 pub struct ConfigGetChat {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername)
@@ -639,6 +676,7 @@ pub fn (d Bot) get_chat(conf ConfigGetChat) Chat {
 }
 
 //GetChatAdministrators Use this method to get a list of administrators in a chat. On success, returns an Array of ChatMember objects that contains information about all chat administrators except other bots. If the chat is a group or a supergroup and no administrators were appointed, only the creator will be returned.
+[params]
 pub struct ConfigGetChatAdministrators {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername)
@@ -649,6 +687,7 @@ pub fn (d Bot) get_chat_administrators(conf ConfigGetChatAdministrators) []ChatM
 }
 
 //GetChatMembersCount Use this method to get the number of members in a chat. Returns Int on success.
+[params]
 pub struct ConfigGetChatMembersCount {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername)
@@ -659,6 +698,7 @@ pub fn (d Bot) get_chat_members_count(conf ConfigGetChatMembersCount) int {
 }
 
 //GetChatMember Use this method to get information about a member of a chat. Returns a ChatMember object on success.
+[params]
 pub struct ConfigGetChatMember {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername)
@@ -670,6 +710,7 @@ pub fn (d Bot) get_chat_member(conf ConfigGetChatMember) ChatMember {
 }
 
 //SetChatStickerSet Use this method to set a new group sticker set for a supergroup. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Use the field can_set_sticker_set optionally returned in getChat requests to check if the bot can use this method. Returns True on success.
+[params]
 pub struct ConfigSetChatStickerSet {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
@@ -681,6 +722,7 @@ pub fn (d Bot) set_chat_sticker_set(conf ConfigSetChatStickerSet) bool {
 }
 
 //DeleteChatStickerSet Use this method to delete a group sticker set from a supergroup. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Use the field can_set_sticker_set optionally returned in getChat requests to check if the bot can use this method. Returns True on success.
+[params]
 pub struct ConfigDeleteChatStickerSet {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
@@ -691,6 +733,7 @@ pub fn (d Bot) delete_chat_sticker_set(conf ConfigDeleteChatStickerSet) bool {
 }
 
 //AnswerCallbackQuery Use this method to send answers to callback queries sent from inline keyboards. The answer will be displayed to the user as a notification at the top of the chat screen or as an alert. On success, True is returned.
+[params]
 pub struct ConfigAnswerCallbackQuery {
 pub:
 	callback_query_id string //Unique identifier for the query to be answered
@@ -705,6 +748,7 @@ pub fn (d Bot) answer_callback_query(conf ConfigAnswerCallbackQuery) bool {
 }
 
 //SetMyCommands Use this method to change the list of the bot's commands. Returns True on success.
+[params]
 pub struct ConfigSetMyCommands {
 pub:
 	commands string //json.encode(BotCommand[]) A JSON-serialized list of bot commands to be set as the list of the bot's commands. At most 100 commands can be specified.
@@ -721,6 +765,7 @@ pub fn (d Bot) get_my_commands() []BotCommand {
 }
 
 //EditMessageText Use this method to edit text and game messages. On success, if edited message is sent by the bot, the edited Message is returned, otherwise True is returned.
+[params]
 pub struct ConfigEditMessageText {
 pub:
 	chat_id string //Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -737,6 +782,7 @@ pub fn (d Bot) edit_message_text(conf ConfigEditMessageText) Message {
 }
 
 //EditMessageCaption Use this method to edit captions of messages. On success, if edited message is sent by the bot, the edited Message is returned, otherwise True is returned.
+[params]
 pub struct ConfigEditMessageCaption {
 pub:
 	chat_id string //Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -752,6 +798,7 @@ pub fn (d Bot) edit_message_caption(conf ConfigEditMessageCaption) Message {
 }
 
 //EditMessageMedia Use this method to edit animation, audio, document, photo, or video messages. If a message is a part of a message album, then it can be edited only to a photo or a video. Otherwise, message type can be changed arbitrarily. When inline message is edited, new file can't be uploaded. Use previously uploaded file via its file_id or specify a URL. On success, if the edited message was sent by the bot, the edited Message is returned, otherwise True is returned.
+[params]
 pub struct ConfigEditMessageMedia {
 pub:
 	chat_id string //Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -766,6 +813,7 @@ pub fn (d Bot) edit_message_media(conf ConfigEditMessageMedia) Message {
 }
 
 //EditMessageReplyMarkup Use this method to edit only the reply markup of messages. On success, if edited message is sent by the bot, the edited Message is returned, otherwise True is returned.
+[params]
 pub struct ConfigEditMessageReplyMarkup {
 pub:
 	chat_id string //Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -779,6 +827,7 @@ pub fn (d Bot) edit_message_reply_markup(conf ConfigEditMessageReplyMarkup) Mess
 }
 
 //StopPoll Use this method to stop a poll which was sent by the bot. On success, the stopped Poll with the final results is returned.
+[params]
 pub struct ConfigStopPoll {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -791,6 +840,7 @@ pub fn (d Bot) stop_poll(conf ConfigStopPoll) Poll {
 }
 
 //DeleteMessage Use this method to delete a message, including service messages, with the following limitations:- A message can only be deleted if it was sent less than 48 hours ago.- A dice message in a private chat can only be deleted if it was sent more than 24 hours ago.- Bots can delete outgoing messages in private chats, groups, and supergroups.- Bots can delete incoming messages in private chats.- Bots granted can_post_messages permissions can delete outgoing messages in channels.- If the bot is an administrator of a group, it can delete any message there.- If the bot has can_delete_messages permission in a supergroup or a channel, it can delete any message there.Returns True on success.
+[params]
 pub struct ConfigDeleteMessage {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -802,6 +852,7 @@ pub fn (d Bot) delete_message(conf ConfigDeleteMessage) bool {
 }
 
 //SendSticker Use this method to send static .WEBP or animated .TGS stickers. On success, the sent Message is returned.
+[params]
 pub struct ConfigSendSticker {
 pub:
 	chat_id string //Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -816,6 +867,7 @@ pub fn (d Bot) send_sticker(conf ConfigSendSticker) Message {
 }
 
 //GetStickerSet Use this method to get a sticker set. On success, a StickerSet object is returned.
+[params]
 pub struct ConfigGetStickerSet {
 pub:
 	name string //Name of the sticker set
@@ -826,6 +878,7 @@ pub fn (d Bot) get_sticker_set(conf ConfigGetStickerSet) StickerSet {
 }
 
 //UploadStickerFile Use this method to upload a .PNG file with a sticker for later use in createNewStickerSet and addStickerToSet methods (can be used multiple times). Returns the uploaded File on success.
+[params]
 pub struct ConfigUploadStickerFile {
 pub:
 	user_id int //User identifier of sticker file owner
@@ -837,6 +890,7 @@ pub fn (d Bot) upload_sticker_file(conf ConfigUploadStickerFile) File {
 }
 
 //CreateNewStickerSet Use this method to create a new sticker set owned by a user. The bot will be able to edit the sticker set thus created. You must use exactly one of the fields png_sticker or tgs_sticker. Returns True on success.
+[params]
 pub struct ConfigCreateNewStickerSet {
 pub:
 	user_id int //User identifier of created sticker set owner
@@ -854,6 +908,7 @@ pub fn (d Bot) create_new_sticker_set(conf ConfigCreateNewStickerSet) bool {
 }
 
 //AddStickerToSet Use this method to add a new sticker to a set created by the bot. You must use exactly one of the fields png_sticker or tgs_sticker. Animated stickers can be added to animated sticker sets and only to them. Animated sticker sets can have up to 50 stickers. Static sticker sets can have up to 120 stickers. Returns True on success.
+[params]
 pub struct ConfigAddStickerToSet {
 pub:
 	user_id int //User identifier of sticker set owner
@@ -869,6 +924,7 @@ pub fn (d Bot) add_sticker_to_set(conf ConfigAddStickerToSet) bool {
 }
 
 //SetStickerPositionInSet Use this method to move a sticker in a set created by the bot to a specific position. Returns True on success.
+[params]
 pub struct ConfigSetStickerPositionInSet {
 pub:
 	sticker string //File identifier of the sticker
@@ -880,6 +936,7 @@ pub fn (d Bot) set_sticker_position_in_set(conf ConfigSetStickerPositionInSet) b
 }
 
 //DeleteStickerFromSet Use this method to delete a sticker from a set created by the bot. Returns True on success.
+[params]
 pub struct ConfigDeleteStickerFromSet {
 pub:
 	sticker string //File identifier of the sticker
@@ -890,6 +947,7 @@ pub fn (d Bot) delete_sticker_from_set(conf ConfigDeleteStickerFromSet) bool {
 }
 
 //SetStickerSetThumb Use this method to set the thumbnail of a sticker set. Animated thumbnails can be set for animated sticker sets only. Returns True on success.
+[params]
 pub struct ConfigSetStickerSetThumb {
 pub:
 	name string //Sticker set name
@@ -902,6 +960,7 @@ pub fn (d Bot) set_sticker_set_thumb(conf ConfigSetStickerSetThumb) bool {
 }
 
 //AnswerInlineQuery Use this method to send answers to an inline query. On success, True is returned.No more than 50 results per query are allowed.
+[params]
 pub struct ConfigAnswerInlineQuery {
 pub:
 	inline_query_id string //Unique identifier for the answered query
@@ -918,6 +977,7 @@ pub fn (d Bot) answer_inline_query(conf ConfigAnswerInlineQuery) bool {
 }
 
 //SendInvoice Use this method to send invoices. On success, the sent Message is returned.
+[params]
 pub struct ConfigSendInvoice {
 pub:
 	chat_id string //Unique identifier for the target private chat
@@ -950,6 +1010,7 @@ pub fn (d Bot) send_invoice(conf ConfigSendInvoice) Message {
 }
 
 //AnswerShippingQuery If you sent an invoice requesting a shipping address and the parameter is_flexible was specified, the Bot API will send an Update with a shipping_query field to the bot. Use this method to reply to shipping queries. On success, True is returned.
+[params]
 pub struct ConfigAnswerShippingQuery {
 pub:
 	shipping_query_id string //Unique identifier for the query to be answered
@@ -963,6 +1024,7 @@ pub fn (d Bot) answer_shipping_query(conf ConfigAnswerShippingQuery) bool {
 }
 
 //AnswerPreCheckoutQuery Once the user has confirmed their payment and shipping details, the Bot API sends the final confirmation in the form of an Update with the field pre_checkout_query. Use this method to respond to such pre-checkout queries. On success, True is returned. Note: The Bot API must receive an answer within 10 seconds after the pre-checkout query was sent.
+[params]
 pub struct ConfigAnswerPreCheckoutQuery {
 pub:
 	pre_checkout_query_id string //Unique identifier for the query to be answered
@@ -975,6 +1037,7 @@ pub fn (d Bot) answer_pre_checkout_query(conf ConfigAnswerPreCheckoutQuery) bool
 }
 
 //SetPassportDataErrors Informs a user that some of the Telegram Passport elements they provided contains errors. The user will not be able to re-submit their Passport to you until the errors are fixed (the contents of the field for which you returned the error must change). Returns True on success. Use this if the data submitted by the user doesn't satisfy the standards your service requires for any reason. For example, if a birthday date seems invalid, a submitted document is blurry, a scan shows evidence of tampering, etc. Supply some details in the error message to make sure the user knows how to correct the issues.
+[params]
 pub struct ConfigSetPassportDataErrors {
 pub:
 	user_id int //User identifier
@@ -986,6 +1049,7 @@ pub fn (d Bot) set_passport_data_errors(conf ConfigSetPassportDataErrors) bool {
 }
 
 //SendGame Use this method to send a game. On success, the sent Message is returned.
+[params]
 pub struct ConfigSendGame {
 pub:
 	chat_id string //Unique identifier for the target chat
@@ -1000,6 +1064,7 @@ pub fn (d Bot) send_game(conf ConfigSendGame) Message {
 }
 
 //SetGameScore Use this method to set the score of the specified user in a game. On success, if the message was sent by the bot, returns the edited Message, otherwise returns True. Returns an error, if the new score is not greater than the user's current score in the chat and force is False.
+[params]
 pub struct ConfigSetGameScore {
 pub:
 	user_id int //User identifier
@@ -1016,6 +1081,7 @@ pub fn (d Bot) set_game_score(conf ConfigSetGameScore) Message {
 }
 
 //GetGameHighScores Use this method to get data for high score tables. Will return the score of the specified user and several of their neighbors in a game. On success, returns an Array of GameHighScore objects.
+[params]
 pub struct ConfigGetGameHighScores {
 pub:
 	user_id int //Target user id


### PR DESCRIPTION
Hi !

I wanted to use vgram but the Config struct could not work unless their names were specified, so I used the `[params]` tag on every method that use Config struct to allow passing parameters more easily.

I hope it suits the project, I tested it locally and found no evident issues.