### PR TITLE
Replaced field text by field body

### DIFF
--- a/vgram.v
+++ b/vgram.v
@@ -22,13 +22,13 @@ fn (d Bot) http_request(method string, _data string) string {
         return ""
     }
     if result.status_code == 200 {
-        xtgresp := json.decode(ResponserOK, result.text) or { 
+        xtgresp := json.decode(ResponserOK, result.body) or { 
             println("Failed to decode json")
             return ""
         }
     	return xtgresp.result
     } else {
-        xtgresp := json.decode(ResponserNotOK, result.text) or { 
+        xtgresp := json.decode(ResponserNotOK, result.body) or { 
             println("Failed to decode json")
             return ""
         }


### PR DESCRIPTION
.vmodules/dariotarantini/vgram/vgram.v:31:55: notice: field `text` will be deprecated after 2022-10-03, and will become an error after 2023-04-01; use Response.body instead